### PR TITLE
Prevent crashes when reading a file that is not JSON

### DIFF
--- a/www/nodejs-project/index.js
+++ b/www/nodejs-project/index.js
@@ -177,14 +177,11 @@ app.post('/readFile', async function (request, response) {
     var url = request.body.url;
     var datName = url.replace('dat://','')
     var localPath = datGatewayRoot + '/' + datName
-    console.log("loading into DatArchive " + localPath)
     var datOptions = {latest: true}
     var netOptions = null;
     let data = {localPath, datOptions, netOptions}
     var archive = await DatArchive.load(data)
-    console.log("now reading the file " + filename)
-    var manifest = JSON.parse(await archive.readFile(filename))
-    response.send(JSON.stringify(manifest))
+    response.send(await archive.readFile(filename))
 });
 
 app.post('/mkdir', async function (request, response, next) {

--- a/www/nodejs-project/test/assets/js/index.js
+++ b/www/nodejs-project/test/assets/js/index.js
@@ -42,9 +42,9 @@ async function readFile() {
         let url = Test.archive.url
         let filename = "/dat.json"
         try {
-            let readFile = await Test.archive.readFile(filename)
-            console.log("readFile returned" + JSON.stringify(readFile))
-            document.querySelector("#readFileResponse").innerHTML = JSON.stringify(readFile)
+            let fileContents = await Test.archive.readFile(filename)
+            console.log("readFile returned" + fileContents)
+            document.querySelector("#readFileResponse").innerHTML = fileContents
         } catch (e) {
             console.log("Error reading " + url + " error: " + JSON.stringify(e))
         }


### PR DESCRIPTION
In the test we read a file that is JSON, but files are not always JSON. This was an assumption baked into the serverside which will cause the server to crash if reading a file that is not JSON.